### PR TITLE
Remove Font Blur on Retina Displays

### DIFF
--- a/MeetGavernWP/css/shortcodes.template.css
+++ b/MeetGavernWP/css/shortcodes.template.css
@@ -34,7 +34,7 @@
 }
 
 body.loaded .gk-big-header {
-	-webkit-filter: blur(0px);
+	-webkit-filter: none;
 }
 
 .gk-big-header span {


### PR DESCRIPTION
On the Macbook Pro Retina, blur(0px) is still blury.  This patch fixes that.
