### PR TITLE
Fixed child theme compatibility

### DIFF
--- a/MeetGavernWP/gavern/form.parser.php
+++ b/MeetGavernWP/gavern/form.parser.php
@@ -9,7 +9,7 @@ defined('GAVERN_WP') or die('Access denied');
  *
  **/
 
-include_once(TEMPLATEPATH . '/gavern/form_elements/standard.php');
+include_once(gavern_file('gavern/form_elements/standard.php'));
 
 /**
  *
@@ -114,7 +114,7 @@ class GavernWPFormParser {
 						// load these files only once time
 						if(!class_exists($file_config->class)) {
 							// load the main PHP class
-							include_once(TEMPLATEPATH . '/gavern/form_elements/'.($field->type).'/'.($file_config->php));
+							include_once(gavern_file('gavern/form_elements/').($field->type).'/'.($file_config->php));
 						}
 						// create the object
 						if(class_exists($file_config->class)) {

--- a/MeetGavernWP/gavern/layouts/template.php
+++ b/MeetGavernWP/gavern/layouts/template.php
@@ -6,7 +6,7 @@ defined('GAVERN_WP') or die('Access denied');
 // access to the template object
 global $tpl;
 // load the form parser
-include_once(TEMPLATEPATH . '/gavern/form.parser.php');
+include_once(gavern_file('gavern/form.parser.php'));
 // create a new instance of the form parser
 $parser = new GavernWPFormParser($tpl);
 // get the tabs list from the JSON file

--- a/MeetGavernWP/gavern/options.importexport.php
+++ b/MeetGavernWP/gavern/options.importexport.php
@@ -16,7 +16,7 @@ function gavern_importexport_options() {
 	// getting access to the template and database global object. 
 	global $tpl;
 	global $wpdb;
-	wp_register_style('gk-import-export-css', get_template_directory_uri().'/css/back-end/importexport.css');
+	wp_register_style('gk-import-export-css', gavern_file_uri('css/back-end/importexport.css'));
 	wp_enqueue_style('gk-import-export-css');
 
 	// check permissions

--- a/MeetGavernWP/gavern/options.template.php
+++ b/MeetGavernWP/gavern/options.template.php
@@ -40,8 +40,8 @@ function gavern_template_options_js() {
 	if($pagenow == 'admin.php' && isset($_GET['page']) && ($_GET['page'] == 'template_options' || $_GET['page'] == 'gavern-menu')) {
 		wp_enqueue_script('media-upload');
 		wp_enqueue_script('thickbox');
-		wp_register_script('gk-tips-js', get_template_directory_uri().'/js/back-end/libraries/miniTip/miniTip.min.js', array('jquery'));
-		wp_register_script('gk-upload', get_template_directory_uri().'/js/back-end/template.options.js', array('jquery','media-upload','thickbox', 'gk-tips-js'));
+		wp_register_script('gk-tips-js', gavern_file_uri('js/back-end/libraries/miniTip/miniTip.min.js'), array('jquery'));
+		wp_register_script('gk-upload', gavern_file_uri('js/back-end/template.options.js'), array('jquery','media-upload','thickbox', 'gk-tips-js'));
 		wp_enqueue_script('gk-upload');
 		wp_enqueue_script('gk-tips-js');
 		// register and load external components scripts
@@ -65,7 +65,7 @@ function gavern_template_options_js() {
 								if((is_array($file_config) && count($file_config) > 0) || is_object($file_config)) {
 									// load the JS file
 									if($file_config->js != '') {
-										wp_register_script('gk_'.strtolower($file_config->name).'.js', get_template_directory_uri().'/gavern/form_elements/'.($field->type).'/'.($file_config->js));
+										wp_register_script('gk_'.strtolower($file_config->name).'.js', gavern_file_uri('gavern/form_elements/').($field->type).'/'.($file_config->js));
 										wp_enqueue_script('gk_'.strtolower($file_config->name).'.js');
 									}
 								}
@@ -94,8 +94,8 @@ function gavern_template_options_css() {
 	// check the page
 	if($pagenow == 'admin.php' && isset($_GET['page']) && ($_GET['page'] == 'template_options' || $_GET['page'] == 'gavern-menu')) {
 		wp_enqueue_style('thickbox');
-		wp_register_style('gk-tips-css', get_template_directory_uri().'/js/back-end/libraries/miniTip/miniTip.css');
-		wp_register_style('gk-template-css', get_template_directory_uri().'/css/back-end/template.css');
+		wp_register_style('gk-tips-css', gavern_file_uri('js/back-end/libraries/miniTip/miniTip.css'));
+		wp_register_style('gk-template-css', gavern_file_uri('css/back-end/template.css'));
 		wp_enqueue_style('gk-tips-css');
 		wp_enqueue_style('gk-template-css');
 		// register and load external components scripts
@@ -119,7 +119,7 @@ function gavern_template_options_css() {
 								if((is_array($file_config) && count($file_config) > 0) || is_object($file_config)) {
 									// load the CSS file
 									if($file_config->css != '') {
-										wp_register_style('gk_'.strtolower($file_config->name).'.css', get_template_directory_uri().'/gavern/form_elements/'.($field->type).'/'.($file_config->css));
+										wp_register_style('gk_'.strtolower($file_config->name).'.css', gavern_file_uri('gavern/form_elements/').($field->type).'/'.($file_config->css));
 										wp_enqueue_style('gk_'.strtolower($file_config->name).'.css');
 									}
 								}

--- a/MeetGavernWP/gavern/options.updates.php
+++ b/MeetGavernWP/gavern/options.updates.php
@@ -17,7 +17,7 @@ function gavern_updates_options() {
 	    wp_die(__('You don\'t have sufficient permissions to access this page!', GKTPLNAME));  
 	} 
 
-	include_once(TEMPLATEPATH . '/gavern/layouts/updates.php');
+	include_once(gavern_file('gavern/layouts/updates.php'));
 }
 
 /**
@@ -33,7 +33,7 @@ function gavern_updates_options_js() {
 	global $pagenow;
 	// check the page
 	if($pagenow == 'admin.php' && isset($_GET['page']) && ($_GET['page'] == 'updates_options' || $_GET['page'] == 'updates_options')) {
-		wp_register_script('gk-updates-js', get_template_directory_uri().'/js/back-end/updates.options.js', array('jquery'));
+		wp_register_script('gk-updates-js', gavern_file_uri('js/back-end/updates.options.js'), array('jquery'));
 		wp_enqueue_script('gk-updates-js');	
 	}
 }
@@ -51,7 +51,7 @@ function gavern_updates_options_css() {
 	global $pagenow;
 	// check the page
 	if($pagenow == 'admin.php' && isset($_GET['page']) && ($_GET['page'] == 'updates_options' || $_GET['page'] == 'updates_options')) {
-		wp_register_style('gk-updates-css', get_template_directory_uri().'/css/back-end/updates.css');
+		wp_register_style('gk-updates-css', gavern_file_uri('css/back-end/updates.css'));
 		wp_enqueue_style('gk-updates-css');
 	}
 }


### PR DESCRIPTION
Many thanks for the help on your forum, this pull request should fix the fault occurring for any of the other files. 

Allows child themes to override the following files (will work now) 

gavern/form_elements/_.php and *.css
gavern/form.parser.php
gavern/layouts/update.php 
css/backend/_.css (for custom admin styles via child theme) 
js/backend/*.js (custom admin JS via child theme) 
